### PR TITLE
feat : fetch questions from api

### DIFF
--- a/src/app/api/challenge/[id]/route.ts
+++ b/src/app/api/challenge/[id]/route.ts
@@ -1,0 +1,8 @@
+import { proxyJson } from '../../proxy';
+
+export async function GET(
+  _req: Request,
+  { params }: { params: { id: string } }
+) {
+  return proxyJson(`/api/challenge/${params.id}`);
+}

--- a/src/app/api/challenge/get/route.ts
+++ b/src/app/api/challenge/get/route.ts
@@ -1,0 +1,4 @@
+import { proxyJson } from '../../proxy';
+export async function GET() {
+  return proxyJson('/api/challenge/get');
+}

--- a/src/app/api/proxy.ts
+++ b/src/app/api/proxy.ts
@@ -1,0 +1,54 @@
+import { NextResponse } from 'next/server';
+import { cookies } from 'next/headers';
+
+/* 
+    Instead of calling the backend directly from the browser, the frontend calls Next.js Route Handlers, which then forward the request to the backend server-to-server.
+    There was an error when try to access from localhost that's why this was created.
+    Add Backend api url as JUDGE0_API_BASE_URL in .env.Local.
+*/
+
+const API_BASE = process.env.JUDGE0_API_BASE_URL;
+
+type ProxyOptions = {
+  method?: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';
+  body?: unknown;
+  addAuth?: boolean;
+  cache?: RequestCache;
+};
+
+export async function proxyJson(upstreamPath: string, opts: ProxyOptions = {}) {
+  const { method = 'GET', body, addAuth = true, cache = 'no-store' } = opts;
+
+  const token = addAuth
+    ? (await cookies()).get('access_token')?.value
+    : undefined;
+
+  const res = await fetch(`${API_BASE}${upstreamPath}`, {
+    method,
+    cache,
+    headers: {
+      Accept: 'application/json',
+      ...(body ? { 'Content-Type': 'application/json' } : {}),
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+    },
+    body: body ? JSON.stringify(body) : undefined,
+  });
+
+  const contentType = res.headers.get('content-type') ?? '';
+  const payload = contentType.includes('application/json')
+    ? await res.json().catch(() => null)
+    : await res.text().catch(() => '');
+
+  if (!res.ok) {
+    return NextResponse.json(
+      {
+        error: 'Upstream error',
+        status: res.status,
+        payload,
+      },
+      { status: res.status }
+    );
+  }
+
+  return NextResponse.json(payload, { status: res.status });
+}

--- a/src/components/QuestionPreviewCardContainer.tsx
+++ b/src/components/QuestionPreviewCardContainer.tsx
@@ -9,21 +9,27 @@ export default function QuestionPreviewCardContainer() {
   const [questions, setQuestions] = useState<QuestionCardPreview[] | null>(
     null
   );
+  const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
+    let cancelled = false;
+
     const loadQuestions = async () => {
       try {
         const data = await fetchQuestionsPreview();
-        console.log(data);
-
-        setQuestions(data.data);
-      } catch (error) {
-        console.error(error);
+        if (!cancelled) setQuestions(data);
+      } catch (e) {
+        console.error(e);
+        if (!cancelled) setError('Failed to load questions');
       }
     };
-    if (!questions) loadQuestions();
-  }, [questions]);
 
+    loadQuestions();
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
   return (
     <div className="flex justify-center items-center w-full">
       <div className="grid justify-center lg:grid-cols-2 md:grid-cols-3 gap-x-24 gap-y-12 py-24">

--- a/src/lib/api/errors.ts
+++ b/src/lib/api/errors.ts
@@ -1,0 +1,67 @@
+// Error normalization
+// The shared http() client throws AppErrorClass, UI layers can safely handle errors without guessing
+
+export type AppErrorKind =
+  | 'network'
+  | 'http'
+  | 'unauthorized'
+  | 'forbidden'
+  | 'not_found'
+  | 'unknown';
+
+export type AppError = {
+  kind: AppErrorKind;
+  message: string;
+  status?: number;
+  url?: string;
+  method?: string;
+  details?: string;
+};
+
+export function normalizeError(
+  error: unknown,
+  info?: { url?: string; method?: string }
+): AppError {
+  if (error instanceof AppErrorClass) {
+    return error.toJSON();
+  }
+
+  if (error instanceof TypeError) {
+    return {
+      kind: 'network',
+      message: 'Network error. Please check your connection.',
+      ...info,
+    };
+  }
+
+  return {
+    kind: 'unknown',
+    message: 'Something went wrong',
+    details: String(error),
+    ...info,
+  };
+}
+
+export class AppErrorClass extends Error {
+  constructor(
+    public kind: AppErrorKind,
+    public message: string,
+    public status?: number,
+    public url?: string,
+    public method?: string,
+    public details?: string
+  ) {
+    super(message);
+  }
+
+  toJSON(): AppError {
+    return {
+      kind: this.kind,
+      message: this.message,
+      status: this.status,
+      url: this.url,
+      method: this.method,
+      details: this.details,
+    };
+  }
+}

--- a/src/lib/api/http.ts
+++ b/src/lib/api/http.ts
@@ -1,0 +1,59 @@
+import { AppErrorClass } from './errors';
+
+type HttpMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';
+
+type HttpOptions<TBody = unknown> = {
+  method?: HttpMethod;
+  body?: TBody;
+  headers?: HeadersInit;
+  cache?: RequestCache;
+  next?: {
+    revalidate?: number;
+  };
+};
+
+const DEFAULT_HEADERS: HeadersInit = {
+  Accept: 'application/json',
+  'Content-Type': 'application/json',
+};
+
+export async function http<TResponse, TBody = unknown>(
+  url: string,
+  options: HttpOptions<TBody> = {}
+): Promise<TResponse> {
+  const { method = 'GET', body, headers, cache = 'no-store', next } = options;
+
+  const res = await fetch(url, {
+    method,
+    headers: {
+      ...DEFAULT_HEADERS,
+      ...headers,
+    },
+    body: body ? JSON.stringify(body) : undefined,
+    cache,
+    next,
+  });
+
+  if (!res.ok) {
+    let details = '';
+    try {
+      details = await res.text();
+    } catch {}
+
+    let kind: AppErrorClass['kind'] = 'http';
+    if (res.status === 401) kind = 'unauthorized';
+    else if (res.status === 403) kind = 'forbidden';
+    else if (res.status === 404) kind = 'not_found';
+
+    throw new AppErrorClass(
+      kind,
+      `Request failed (${res.status})`,
+      res.status,
+      url,
+      method,
+      details
+    );
+  }
+
+  return (await res.json()) as TResponse;
+}

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -10,10 +10,21 @@ export type Question = {
   description: string;
   sample_input: string;
   sample_output: string;
+  created_at?: string;
 };
 
 export type QuestionTest = {
   code: string;
   sample_input: string;
   sample_output: string;
+};
+
+export type QuestionByIdApiResponse = {
+  challenge: Question;
+};
+
+export type QuestionListApiResponse = {
+  challenges: Question[];
+  currentPage: number;
+  totalPages: number;
 };

--- a/src/utils/fetchQuestions.ts
+++ b/src/utils/fetchQuestions.ts
@@ -1,15 +1,53 @@
-export async function fetchQuestionsPreview() {
-  const res = await fetch('/question.json');
-  if (!res.ok) {
-    throw new Error('Failed to fetch questions preview');
-  }
-  return res.json();
+import type { Question, QuestionCardPreview } from '@/types/types';
+import { http } from '@/lib/api/http';
+
+type ChallengeListApiResponse = {
+  challenges: Array<{
+    id: number;
+    title: string;
+    description: string;
+    sample_input: string;
+    sample_output: string;
+    created_at: string;
+  }>;
+  currentPage: number;
+  totalPages: number;
+};
+
+type ChallengeByIdApiResponse = {
+  challenge: {
+    id: number;
+    title: string;
+    description: string;
+    sample_input: string;
+    sample_output: string;
+    created_at: string;
+  };
+};
+
+// Get all questions
+export async function fetchQuestionsPreview(): Promise<QuestionCardPreview[]> {
+  const data = await http<ChallengeListApiResponse>('/api/challenge/get', {
+    cache: 'no-store',
+  });
+
+  return data.challenges.map((q) => ({
+    id: q.id,
+    title: q.title,
+    description: q.description,
+  }));
 }
 
-export async function fetchQuestion(id: string) {
-  const res = await fetch(`/api/questions/${id}`);
-  if (!res.ok) {
-    throw new Error('Failed to fetch question');
-  }
-  return res.json();
+// Get question details by id
+export async function fetchQuestion(id: string): Promise<Question> {
+  const data = await http<ChallengeByIdApiResponse>(`/api/challenge/${id}`);
+  const q = data.challenge;
+
+  return {
+    id: q.id,
+    title: q.title,
+    description: q.description,
+    sample_input: q.sample_input,
+    sample_output: q.sample_output,
+  };
 }


### PR DESCRIPTION
##  Summary

The changes replace mock-based fetching with a scalable architecture that includes:
- a shared HTTP client
- a server-side proxy to avoid CORS
- normalized error handling
- typed API helpers
- improved client-side data loading
---

## What’s Included

### API & Infrastructure
- ✅ Shared HTTP client (`http.ts`)
  - Supports GET / POST / PUT / PATCH / DELETE
  - Request-level caching configuration
  - Throws normalized errors
  
- ✅ Normalized error model (`errors.ts`)
  - Predictable error shape for UI and services
  
- ✅ Shared server-side proxy helper (`proxy.ts`)
  - Solves CORS issues
  - Injects auth headers securely (server-side)
  - Centralizes backend forwarding logic

### Questions Feature
- ✅ Typed domain and API response models

- ✅ API helpers for:
  - Fetching question list
  - Fetching question by ID
  
- ✅ Client-side question preview loading with loading state

---

##  Why This Change?

- Removes dependency on mock JSON data
- Prevents CORS issues without modifying the backend
- Avoids duplicated `fetch` logic across the app
- Makes API calls predictable, typed, and reusable
- Keeps auth tokens off the client
- Improves maintainability and future scalability

---

## Architectural Notes

- **Browser never calls backend directly**
  - All backend calls go through Next.js API routes
- **Auth headers are injected server-side only**
- **Components do not call `fetch()` directly**
  - They rely on domain-specific API helpers
- **Caching is configurable per request**


---

## How to Test

1. Start the dev server
2. Ensure `.env.local` contains:
   ```bash
   JUDGE0_API_BASE_URL = Backend Secret